### PR TITLE
CI changes

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -186,4 +186,4 @@ jobs:
           context: ci-code-quality
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: needs.pre-commit.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
+        if: steps.repo-dir.outcome == 'success'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -170,7 +170,9 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
-        if: needs.pre-commit.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
+        if: >
+          needs.pre-commit.result != 'skipped' &&
+          needs.set-git-env-vars.result != 'skipped'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -161,11 +161,7 @@ jobs:
   set-status:
     name: Set status on commit
     needs: [pre-commit, set-git-env-vars]
-    if: >
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-      contains(toJson(github.event.head_commit.message), '[skip ci]') == false)
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Get repo dir name
@@ -174,6 +170,7 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
+        if: needs.pre-commit.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x
@@ -189,3 +186,4 @@ jobs:
           context: ci-code-quality
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: needs.pre-commit.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -163,11 +163,7 @@ jobs:
   set-status:
     name: Set status on commit
     needs: [safety, set-git-env-vars]
-    if: >
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-      contains(toJson(github.event.head_commit.message), '[skip ci]') == false)
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Get repo dir name
@@ -176,6 +172,7 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
+        if: needs.safety.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x
@@ -191,3 +188,4 @@ jobs:
           context: ci-dependency-safety
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: needs.safety.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -172,7 +172,9 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
-        if: needs.safety.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
+        if: >
+          needs.safety.result != 'skipped' &&
+          needs.set-git-env-vars.result != 'skipped'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -188,4 +188,4 @@ jobs:
           context: ci-dependency-safety
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: needs.safety.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
+        if: steps.repo-dir.outcome == 'success'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,24 +203,28 @@ jobs:
           import json
           import sys
 
+          needed_ci = ("ci-code-quality", "ci-test-code", "ci-test-docs")
+
           status_json = json.loads("""${{ steps.get-status.outputs.data }}""")
 
-          if status_json["state"] != "success":
-              print("The CI pipeline state of this commit is not 'success'.")
-              sys.exit(1)
-
           ci_that_ran = []
+          unsuccessful_ci = []
           for ci in status_json["statuses"]:
               ci_that_ran.append(ci["context"])
+              if ci["state"] != "success":
+                  unsuccessful_ci.append(ci["context"])
 
-          needed_ci = ("ci-code-quality", "ci-test-code", "ci-test-docs")
+          do_exit_1 = False
           for ci in needed_ci:
               if ci not in ci_that_ran:
-                  print(
-                      "Not all CI pipelines ran. Please make sure all CI pipelines "
-                      f"ran successfully and try again.\nNeeded CI: {needed_ci}"
-                  )
-                  sys.exit(1)
+                  print(f"Needed CI pipeline '{ci}' did not run at all.")
+                  do_exit_1 = True
+              if ci in unsuccessful_ci:
+                  print(f"Needed CI pipeline '{ci}' did not run successfully.")
+                  do_exit_1 = True
+
+          if do_exit_1:
+              sys.exit(1)
 
 
   old-test-code:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -209,12 +209,18 @@ jobs:
               print("The CI pipeline state of this commit is not 'success'.")
               sys.exit(1)
 
-          if len(status_json["statuses"]) < 4:
-              print(
-                  "Not all CI pipelines ran. Please make sure all CI pipelines "
-                  "ran successfully and try again."
-              )
-              sys.exit(1)
+          ci_that_ran = []
+          for ci in status_json["statuses"]:
+              ci_that_ran.append(ci["context"])
+
+          needed_ci = ("ci-code-quality", "ci-test-code", "ci-test-docs")
+          for ci in needed_ci:
+              if ci not in ci_that_ran:
+                  print(
+                      "Not all CI pipelines ran. Please make sure all CI pipelines "
+                      f"ran successfully and try again.\nNeeded CI: {needed_ci}"
+                  )
+                  sys.exit(1)
 
 
   old-test-code:

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -617,11 +617,7 @@ jobs:
   set-status:
     name: Set status on commit
     needs: [test-code, report-coverage, push-coverage-to-code-climate, set-git-env-vars]
-    if: >
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push'
-      && contains(toJson(github.event.head_commit.message), '[skip ci]') == false)
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Process total success
@@ -639,6 +635,11 @@ jobs:
             state=failure
           fi
           echo -e "::set-output name=state::${state}"
+        if: >
+          needs.test-code.result != 'skipped' &&
+          needs.report-coverage.result != 'skipped' &&
+          needs.push-coverage-to-code-climate.result != 'skipped' &&
+          needs.set-git-env-vars.result != 'skipped'
 
       - name: Get repo dir name
         id: repo-dir
@@ -646,6 +647,7 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
+        if: steps.total-success.outcome == 'success'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x
@@ -661,3 +663,4 @@ jobs:
           context: ci-test-code
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.repo-dir.outcome == 'success'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -204,7 +204,9 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
-        if: needs.test-docs.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
+        if: >
+          needs.test-docs.result != 'skipped' &&
+          needs.set-git-env-vars.result != 'skipped'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -195,11 +195,7 @@ jobs:
   set-status:
     name: Set status on commit
     needs: [test-docs, set-git-env-vars]
-    if: >
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-      contains(toJson(github.event.head_commit.message), '[skip ci]') == false)
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Get repo dir name
@@ -208,6 +204,7 @@ jobs:
         run: |
           repo_dir=${GITHUB_REPOSITORY#${{ github.repository_owner }}/}
           echo "::set-output name=repo-dir::$repo_dir"
+        if: needs.test-docs.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
 
       - name: Set status via gihub API
         uses: octokit/request-action@v2.x
@@ -223,3 +220,4 @@ jobs:
           context: ci-test-docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: needs.test-docs.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -220,4 +220,4 @@ jobs:
           context: ci-test-docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: needs.test-docs.result != 'skipped' && needs.set-git-env-vars.result != 'skipped'
+        if: steps.repo-dir.outcome == 'success'


### PR DESCRIPTION
Fix workflows to set status on commits via api not only on `success`, but also on `cancelled` and `failure`.

Remove successful `dependency-safety` workflow as necessity for `publish` workflow.